### PR TITLE
주문페이지 결제수단 - 할부개월 선택 기능 구현

### DIFF
--- a/src/main/webapp/WEB-INF/static/order/css/order.css
+++ b/src/main/webapp/WEB-INF/static/order/css/order.css
@@ -472,9 +472,22 @@ div .popupBtn:hover {
 .monthContentSelect {
     position: relative;
 }
+.selectOptions {
+    display: none;
+    position: absolute;
+    background-color: #fff;
+    border: 1px solid #ccc;
+    max-height: 100px;
+    overflow-y: auto;
+    width: 100%;
+}
+.selectOption {
+    padding: 8px;
+    cursor: pointer;
+}
 .monthSelectInputWrapper {
     padding: 0px 18px;
-    background: rgba(240, 240, 240, 0.7);
+    background-color: #fff;
     border: 1px solid rgb(228, 228, 228);
     color: rgb(61, 61, 61);
     max-height: 44px;
@@ -485,6 +498,9 @@ div .popupBtn:hover {
     letter-spacing: -0.015em;
     align-items: center;
     border-radius: 1px;
+}
+.disabled {
+    background: rgba(240, 240, 240, 0.7);
 }
 .inputInner {
     width: 100%;

--- a/src/main/webapp/WEB-INF/static/pay/js/orderPayMeans.js
+++ b/src/main/webapp/WEB-INF/static/pay/js/orderPayMeans.js
@@ -44,12 +44,59 @@ $(document).ready(function () {
         })
     }
 
+    // 할부개월 Select Options 렌더링
+    const cardInstallList = ['일시불', '2개월(무이자)', '3개월(무이자)', '4개월', '5개월', '6개월', '7개월',
+    '8개월', '9개월', '10개월', '11개월', '12개월'];
+
+    for (let data of cardInstallList) {
+        $('.selectOptions').append(
+            `<div class="selectOption" data-value="${data}">${data}</div>`
+        );
+    }
+
+    // 할부개월 Select Option 클릭 이벤트
+    $('.selectOptions').on('click', '.selectOption', function() {
+        let selectedOption = $(this).data('value');
+        $('#cardInstallInput').prop("value", selectedOption);
+    });
+
+    // 할부개월 Select Box 조작
+    function handleCardInstallUI(cardType) {
+        console.log("selectedPayMeans: " + selectedPayMeans)
+        console.log("cardType: " + cardType)
+        let totalMoney = BigInt($('.totalMoney').text()); // TODO: 최종 후원 금액(BigInt) (임시)
+
+        // 신용카드이고 최종후원금액이 5만원 이상인 경우, 할부개월 Select Box 활성화
+        if (cardType === 0 && totalMoney < 50000) {
+            $('.monthSelectInputWrapper').removeClass('disabled'); // css 변경
+
+            // 할부개월 Select Box 클릭하면 Select Option 열림
+            $(".monthSelectInputWrapper").on("click", function (e) {
+                e.stopPropagation();
+                $(".selectOptions").toggle();
+            });
+        } else {
+            $(".monthSelectInputWrapper").off("click"); // 클릭 이벤트 핸들러 제거
+            $('.monthSelectInputWrapper').addClass('disabled'); // css 변경
+            $('#cardInstallInput').prop("value", "일시불"); // 일시불로 초기화
+        }
+    }
+
+    $(document).on("click", function (e) {
+        // 다른 곳 클릭하면 할부개월 Select Option 닫음
+        if ($(e.target).closest(".monthSelectInputWrapper").length === 0) {
+            $(".selectOptions").hide();
+        }
+    })
+
     // 주문페이지에 대표 결제수단 렌더링
     function renderPayOnOrderPage(payMeans) {
         // 대표 결제수단으로 저장
         updateSelectedPayMeans(payMeans)
         // 주문페이지에 대표 결제수단 렌더링
         appendPayOnOrderPage()
+        // 할부개월 Select Box UI 제어
+        handleCardInstallUI(selectedPayMeans.card_type);
     }
 
     // 결제수단변경 팝업창에 결제수단 리스트 렌더링
@@ -172,8 +219,8 @@ $(document).ready(function () {
 
     // TODO: 주문페이지 '후원하기' 버튼 클릭 이벤트
     $("#orderBtn").click(function () {
-        // 선택된 결제수단 데이터: selectedPayMeans
-        console.log(selectedPayMeans)
+        console.log(selectedPayMeans); // 선택된 결제수단 데이터: selectedPayMeans
+        console.log($('#cardInstallInput').prop("value")); // 신용카드 할부개월 데이터
 
         // '기본 결제수단으로 등록'을 선택한 경우
         if ($('#updateDefaultCheckbox').is(':checked')) {

--- a/src/main/webapp/WEB-INF/static/pay/js/orderPayMeans.js
+++ b/src/main/webapp/WEB-INF/static/pay/js/orderPayMeans.js
@@ -67,7 +67,7 @@ $(document).ready(function () {
         let totalMoney = BigInt($('.totalMoney').text()); // TODO: 최종 후원 금액(BigInt) (임시)
 
         // 신용카드이고 최종후원금액이 5만원 이상인 경우, 할부개월 Select Box 활성화
-        if (cardType === 0 && totalMoney < 50000) {
+        if (cardType === 0 && totalMoney >= 50000) {
             $('.monthSelectInputWrapper').removeClass('disabled'); // css 변경
 
             // 할부개월 Select Box 클릭하면 Select Option 열림

--- a/src/main/webapp/WEB-INF/views/order/order.jsp
+++ b/src/main/webapp/WEB-INF/views/order/order.jsp
@@ -212,13 +212,14 @@
                                                         <div class="monthContentSelectWrapper">
                                                             <div class="monthContentSelect">
                                                                 <span class="monthSelectInputWrapper">
-                                                                    <input disabled="" readonly="" type="text" inputmode="text" autocapitalize="off" autocomplete="off" class="inputInner" value="일시불">
+                                                                    <input id="cardInstallInput" readonly type="text" inputmode="text" autocapitalize="off" autocomplete="off" class="inputInner" value="일시불">
                                                                     <div class="arrowDownIcon">
                                                                         <svg viewBox="0 0 48 48">
                                                                             <path fill-rule="evenodd" clip-rule="evenodd" d="M2 14.4065C2 13.1363 3.09843 12.0615 4.39657 12.0615C4.99571 12.0615 5.59485 12.257 6.09414 12.7455L23.9685 29.4526L41.843 12.6478C42.8415 11.7684 44.3394 11.7684 45.338 12.7455C46.2367 13.7226 46.2367 15.1882 45.2381 16.0676L23.9685 36L2.79886 16.0676C2.29957 15.6767 2 14.9928 2 14.4065Z"></path>
                                                                         </svg>
                                                                     </div>
                                                                 </span>
+                                                                <div class="selectOptions"></div>
                                                             </div>
                                                         </div>
                                                         <div class="cardInstallGuide">
@@ -259,7 +260,7 @@
                         <div class="totalBox">
                             <div class="totalBoxConts">
                                 <div class="totalName">최종 후원 금액</div>
-                                <div class="totalMoney">22,000원</div>
+                                <div class="totalMoney">22000</div>원
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
결제수단이 신용카드 && 주문금액이 50,000원 이상인 경우, 할부개월 선택할 수 있는 기능 추가
- [update: 주문페이지 결제수단 신용카드 할부개월 기능 추가](https://github.com/mulgoms2/Fundly/commit/32a929bdfc62512f24028b6ebef0c81700816179)
- [fix: 금액 조건 부등호 수정](https://github.com/mulgoms2/Fundly/commit/303b6a9e2c283540366f6ff6f18e04322b0dd4ac)