### PR TITLE
bug fix: 결제수단 등록 시 발생하는 기본결제수단지정 관련 버그들 fix

### DIFF
--- a/src/main/java/com/persistence/dto/PayMeansDto.java
+++ b/src/main/java/com/persistence/dto/PayMeansDto.java
@@ -18,7 +18,7 @@ public class PayMeansDto {
     private String own_type; // 카드소유주/예금주 유형 (개인, 법인)
     @NonNull
     private String own_birth; // 생년월일
-    private String bill_key; // 포트원 결제수단별 등록키 TODO: DB 컬럼 새로 추가
+    private String bill_key; // 포트원 결제수단별 등록키
     private String file_path; // 결제수단 이미지 파일 경로
     private String file_name; // 결제수단 이미지 파일명
     private String file_extension; // 결제수단 이미지 파일 확장자
@@ -26,12 +26,12 @@ public class PayMeansDto {
     private String card_co_info_agree_yn; // 결제사 정보제공 동의 여부
     private String card_co_type; // 카드사 종류
     @NonNull
-    private String card_no; // 카드 뒷자리 번호 4개 TODO: DB 컬럼 새로 추가
+    private String card_no; // 카드 뒷자리 번호 4개
     @NonNull
-    private String card_pwd; // 카드 비밀번호 앞 2자리 TODO: DB 타입 변경 (Integer -> String)
+    private String card_pwd; // 카드 비밀번호 앞 2자리
     @NonNull
     private String card_valid_date; // 카드 유효기간
-    private Integer card_type; // 카드 타입 (신용카드 == 0, 체크카드 == 1) TODO: DB 컬럼 새로 추가
+    private Integer card_type; // 카드 타입 (신용카드 == 0, 체크카드 == 1)
 
     // dba
     @EqualsAndHashCode.Exclude

--- a/src/main/webapp/WEB-INF/static/pay/js/registerPayMeans.js
+++ b/src/main/webapp/WEB-INF/static/pay/js/registerPayMeans.js
@@ -8,6 +8,16 @@ $(document).ready(function () {
     $('#form')[0].reset();
     resetErrMsg();
 
+    // 기본결제수단으로지정 체크박스 값 세팅
+    setDefaultPayMeansValue()
+
+    function setDefaultPayMeansValue() {
+        let value = $('#default_pay_means_yn').is(':checked') ? 'Y' : 'N';
+        $('#default_pay_means_yn').val(value.trim());
+
+        console.log($('#default_pay_means_yn').val() + " " + $('#default_pay_means_yn').val().length);
+    }
+
     // 결제수단등록 팝업 유효성 에러 메세지 리셋
     function resetErrMsg() {
         $('#card_pwd_err_msg').text('');
@@ -77,18 +87,22 @@ $(document).ready(function () {
         );
     });
 
+    $('#default_pay_means_yn').change(function(){
+        setDefaultPayMeansValue();
+    });
+
     $("#submitBtn").click(function () {
         resetErrMsg(); // 초기화
         $('#card_no').val($('#card_no_1').val() + $('#card_no_2').val() + $('#card_no_3').val() + $('#card_no_4').val());
 
         let formData = {
-            own_type: $('input[name="own_type"]:checked').val(),
-            card_no: $('#card_no').val(),
-            card_valid_date: $('#card_valid_date').val(),
-            own_birth: $('#own_birth').val(),
-            card_pwd: $('#card_pwd').val(),
-            card_co_info_agree_yn: $('#card_co_info_agree_yn').val(),
-            default_pay_means_yn: $('#default_pay_means_yn').val()
+            own_type: $('input[name="own_type"]:checked').val().trim(),
+            card_no: $('#card_no').val().trim(),
+            card_valid_date: $('#card_valid_date').val().trim(),
+            own_birth: $('#own_birth').val().trim(),
+            card_pwd: $('#card_pwd').val().trim(),
+            card_co_info_agree_yn: $('#card_co_info_agree_yn').val().trim(),
+            default_pay_means_yn: $('#default_pay_means_yn').val().trim()
         };
 
         if (!$("#card_co_info_agree_yn").prop("checked")) {
@@ -104,7 +118,6 @@ $(document).ready(function () {
                     location.reload();
                 },
                 error: function (e) {
-                    // alert("결제수단 등록에 실패했습니다. 다시 시도해주세요.");
                     console.log(e)
                     const code = e.responseJSON.code;
                     let inputErrMsg = "";

--- a/src/main/webapp/WEB-INF/views/pay/registerCardFormPop.jsp
+++ b/src/main/webapp/WEB-INF/views/pay/registerCardFormPop.jsp
@@ -89,7 +89,7 @@
                     <div class="errorMsg" id="card_co_info_agree_yn_err_msg"></div>
                 </div>
                 <div class="checkboxInputWrapper">
-                    <input class="checkboxInput" id="default_pay_means_yn" type="checkbox" name="default_pay_means_yn" value="Y" checked>기본 결제수단으로 등록
+                    <input class="checkboxInput" id="default_pay_means_yn" type="checkbox" name="default_pay_means_yn" checked>기본 결제수단으로 등록
                 </div>
             </div>
         </form>


### PR DESCRIPTION
**bug fix: 결제수단 등록 시 발생하는 기본결제수단지정 관련 버그들 fix**
1. 등록된 카드가 없을 때, 기본결제수단 체크하지 않았음에도 불구하고 기본결제수단으로 등록되는 이슈
-> default로 지정해놨던 <input> 태그의 value 속성값 제거하여 해결.

2. 1번 해결 후 생긴 이슈
: 기본결제수단지정 체크박스 변경하지 않고 초기에 checked된 그대로 결제수단 등록 시, com.mysql.cj.jdbc.exceptions.MysqlDataTruncation: Data truncation: Data too long for column 'default_pay_means_yn' at row 1 에러 발생
-> 해당 에러는 DB에 지정된 값의 길이(== 1)를 초과했을 때 발생하는 에러로, default로 지정해놨던 <input> 태그의 value 속성값 제거 후 'on'이라는 값이 세팅되기 때문에 form 제출 시 길이가 1을 넘었기 때문. 페이지 렌더링 시 <input> checked 값에 따른 value 값 세팅되도록 하는 메서드 추가하여 해결.

- [fix: 기본결제수단 체크박스 value에 따른 결제수단등록 실패 이슈 fix](https://github.com/mulgoms2/Fundly/commit/e663b1db70890e07dbf9f815b93e99f7053d4456)
- [refactor: 코드 리팩토링 및 불필요한 주석 제거](https://github.com/mulgoms2/Fundly/commit/8fbbf77a74edf2a0f9734c2b6bc334390f371f68)